### PR TITLE
Fixed version number for required component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "lstrojny/functional-php": "dev-master",
+        "lstrojny/functional-php": "1.0.*@dev",
         "internations/solr-utils": "dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
Got on error installing this package.

> internations/solr-query-component dev-master requires lstrojny/functional-php dev-master -> no matching package found.

According to packagist the dependency for https://packagist.org/packages/lstrojny/functional-php should be 

> "lstrojny/functional-php": "1.0.*@dev"
