### PR TITLE
Adding andX, orX to the ExpressionBuilder

### DIFF
--- a/src/InterNations/Component/Solr/Expression/ExpressionBuilder.php
+++ b/src/InterNations/Component/Solr/Expression/ExpressionBuilder.php
@@ -264,6 +264,40 @@ class ExpressionBuilder
     }
 
     /**
+     * Create AND grouped expression: (<expr1> AND <expr2> AND <expr3>)
+     *
+     * @param Expression|string $expr, ...
+     * @param string $type
+     * @return Expression
+     */
+    public function andX($expr = null)
+    {
+        $args = func_get_args();
+        if (!$args) {
+            return null;
+        }
+
+        return new GroupExpression($args, GroupExpression::TYPE_AND);
+    }
+
+    /**
+     * Create OR grouped expression: (<expr1> OR <expr2> OR <expr3>)
+     *
+     * @param Expression|string $expr, ...
+     * @param string $type
+     * @return Expression
+     */
+    public function orX($expr = null)
+    {
+        $args = func_get_args();
+        if (!$args) {
+            return null;
+        }
+
+        return new GroupExpression($args, GroupExpression::TYPE_OR);
+    }
+
+    /**
      * Returns a query "*:*" which means find all if $expr is empty
      *
      * @param Expression|string $expr

--- a/tests/InterNations/Component/Solr/Tests/Expression/ExpressionBuilderTest.php
+++ b/tests/InterNations/Component/Solr/Tests/Expression/ExpressionBuilderTest.php
@@ -129,6 +129,20 @@ class ExpressionBuilderTest extends AbstractTestCase
         $this->assertSame('("bar" "foo" "baz")', (string) $g);
     }
 
+    public function testGroupingWithAndX()
+    {
+        $g = $this->eb->andX($this->eb->phrase('foo'), $this->eb->phrase('bar'), $this->eb->phrase('baz'));
+        $this->assertInstanceOf('InterNations\Component\Solr\Expression\GroupExpression', $g);
+        $this->assertSame('("foo" AND "bar" AND "baz")', (string) $g);
+    }
+
+    public function testGroupingWithOrX()
+    {
+        $g = $this->eb->orX($this->eb->phrase('foo'), $this->eb->phrase('bar'), $this->eb->phrase('baz'));
+        $this->assertInstanceOf('InterNations\Component\Solr\Expression\GroupExpression', $g);
+        $this->assertSame('("foo" OR "bar" OR "baz")', (string) $g);
+    }
+
     public function testField()
     {
         $f = $this->eb->field('field', 'query');


### PR DESCRIPTION
Adding andX and orX to the ExpressionBuilder.

`$builder->andX($builder->field('foo', 'bar'), $builder->field('bar', 'baz'));`

Against

`$builder->grp($builder->field('foo', 'bar'), $builder->field('bar', 'baz'), GroupExpression::TYPE_AND);`
