### PR TITLE
Format correct messages for InvalidArgumentException 

### DIFF
--- a/src/InterNations/Component/Solr/Expression/Exception/InvalidArgumentException.php
+++ b/src/InterNations/Component/Solr/Expression/Exception/InvalidArgumentException.php
@@ -27,6 +27,10 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements E
     {
         $last = array_pop($expectation);
 
+        if (!$expectation) {
+            return $last;
+        }
+
         return implode($expectation, ', ') . ' or ' . $last;
     }
 

--- a/tests/InterNations/Component/Solr/Tests/Expression/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/InterNations/Component/Solr/Tests/Expression/Exception/InvalidArgumentExceptionTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace InterNations\Component\Solr\Tests\Expression\Exception;
+
+use InterNations\Component\Solr\Expression\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class InvalidArgumentExceptionTest extends TestCase
+{
+
+    /** @dataProvider provideExpectationsForMessages */
+    public  function testInvalidArgumentMessages(array $expectations, string $message)
+    {
+        $position = 2;
+        $name = 'variable';
+        $actual = [];
+
+        $expectedMessage = sprintf(
+            'Invalid argument #%d $%s given: expected %s, got %s',
+            $position,
+            $name,
+            $message,
+            gettype($actual)
+        );
+
+        $exception = InvalidArgumentException::invalidArgument($position, $name, $expectations, $actual);
+
+        $this->assertSame($expectedMessage, $exception->getMessage());
+    }
+
+    public static function provideExpectationsForMessages()
+    {
+        return [
+            'Single expectation' => [['string'], 'string'],
+            'Two expectations' => [['string', 'integer'], 'string or integer'],
+            'More expectations' => [['string', 'boolean', 'integer', 'object'], 'string, boolean, integer or object'],
+        ];
+    }
+}


### PR DESCRIPTION
If single expectation given current message looks wrong: ``Invalid argument #2 $variable given: expected  or string, got array``.

This PR fixes this case and adds tests for the format of InvalidArgumentException messages.