### PR TITLE
Test improvements about fixtures and autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,13 @@
         "phpunit/phpunit": "~6"
     },
     "autoload": {
-        "psr-0": {
-            "InterNations\\Component\\Solr": "src/"
+        "psr-4": {
+            "InterNations\\Component\\Solr\\": "src/InterNations/Component/Solr"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "InterNations\\Component\\Solr\\Tests\\": "tests/InterNations/Component/Solr/Tests"
         }
     },
     "extra": {

--- a/tests/InterNations/Component/Solr/Tests/Expression/ExpressionBuilderTest.php
+++ b/tests/InterNations/Component/Solr/Tests/Expression/ExpressionBuilderTest.php
@@ -4,7 +4,6 @@ namespace InterNations\Component\Solr\Tests\Expression;
 use InterNations\Component\Solr\Expression\CompositeExpression;
 use InterNations\Component\Solr\Expression\ExpressionBuilder;
 use InterNations\Component\Solr\Expression\GroupExpression;
-use InterNations\Component\Solr\Expression\ParameterExpression;
 use InterNations\Component\Testing\AbstractTestCase;
 use DateTime;
 use DateTimeZone;
@@ -16,7 +15,7 @@ class ExpressionBuilderTest extends AbstractTestCase
      */
     private $eb;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->eb = new ExpressionBuilder();
     }

--- a/tests/InterNations/Component/Solr/Tests/Expression/PerformanceTest.php
+++ b/tests/InterNations/Component/Solr/Tests/Expression/PerformanceTest.php
@@ -12,7 +12,7 @@ class PerformanceTest extends AbstractTestCase
 {
     use TimingTrait;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (extension_loaded('xdebug')) {
             $this->markTestSkipped('xdebug extension is enabled. Performance tests skipped');


### PR DESCRIPTION
# Changed log

- Using the `PSR-4` autoloading to replace `PSR-0` because it has been deprecated.
- The `use InterNations\Component\Solr\Expression\ParameterExpression;` is declared but it's not used.
It should be removed.
- Using the PHPUnit fixtures to be `protected function setUp` and this reference is available [here](https://phpunit.de/manual/6.5/en/fixtures.html#fixtures.more-setup-than-teardown).