### PR TITLE
INDEV-10502 Adopt backwards compatibility checker

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        fetch-depth: 0
 
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
@@ -34,9 +35,16 @@ jobs:
         uses: ramsey/composer-install@v1
         with:
           composer-options: --prefer-dist
+        if: matrix.php-version > 7.1
 
       - name: Run Tests
         run: composer tests
+        if: matrix.php-version > 7.1
 
       - name: Check coding style
         run: composer coding-style
+        if: matrix.php-version > 7.1
+
+      - name: Check backward compatibility
+        run: composer backward-compatibility-check
+        if: matrix.php-version >= 7.4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,6 +46,36 @@ jobs:
         run: composer coding-style
         if: matrix.php-version > 7.1
 
+  bc-checker:
+    name: PHP ${{ matrix.php-version }} bc-checker
+
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 7.4
+          - 8.0
+          - 8.1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: pcov
+          tools: composer:v2
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: --prefer-dist
+
       - name: Check backward compatibility
         run: composer backward-compatibility-check
-        if: matrix.php-version >= 7.4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: PHP ${{ matrix.php-version }}
+    name: PHP ${{ matrix.php-version }} test
 
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        fetch-depth: 0
+        with:
+          fetch-depth: 0
 
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 example.php
 atlassian-ide-plugin.xml
 build/*
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     },
     "require-dev": {
         "internations/kodierungsregelwerksammlung": "~0.35",
-        "phpunit/phpunit": "~7 || ~8 || ~9"
+        "phpunit/phpunit": "~7 || ~8 || ~9",
+        "roave/backward-compatibility-check": "^3 || ^4 || ^5 || ^6"
     },
     "autoload": {
         "psr-0": {
@@ -50,6 +51,7 @@
     },
     "scripts": {
         "tests": "phpunit",
-        "coding-style": "phpcs --standard=vendor/internations/kodierungsregelwerksammlung/ruleset.xml ./src/"
+        "coding-style": "phpcs --standard=vendor/internations/kodierungsregelwerksammlung/ruleset.xml ./src/",
+        "backward-compatibility-check": "roave-backward-compatibility-check"
     }
 }


### PR DESCRIPTION
Integrate https://github.com/Roave/BackwardCompatibilityCheck to make versioning determination more trivial.


I find it good where the checker mentions here, what exactly is the bc breaker.
<img width="1440" alt="Screenshot 2022-03-25 at 9 38 15 AM" src="https://user-images.githubusercontent.com/23334195/160085362-f03693ec-35e8-4b3f-a638-699d44352d74.png">
