### PR TITLE
Remove support of outdated php versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,9 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.1
-          - 7.2
-          - 7.3
           - 7.4
           - 8.0
           - 8.1

--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,14 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
+        "php": ">=7.4",
         "lstrojny/functional-php": "~0.1|~1.0",
         "internations/solr-utils": "~0.8"
     },
     "require-dev": {
         "internations/kodierungsregelwerksammlung": "~0.35",
-        "phpunit/phpunit": "~7 || ~8 || ~9",
-        "roave/backward-compatibility-check": "^3 || ^4 || ^5 || ^6"
+        "phpunit/phpunit": "~9",
+        "roave/backward-compatibility-check": "^5 || ^6"
     },
     "autoload": {
         "psr-0": {

--- a/src/InterNations/Component/Solr/Expression/BooleanExpression.php
+++ b/src/InterNations/Component/Solr/Expression/BooleanExpression.php
@@ -14,19 +14,10 @@ class BooleanExpression extends Expression
     public const OPERATOR_REQUIRED = '+';
     public const OPERATOR_PROHIBITED = '-';
 
-    /**
-     * Boolean operand
-     *
-     * @var string
-     */
-    private $operator;
+    private string $operator;
 
-    /**
-     * Use the NOT notation: (*:* NOT <expr>), e.g. (*:* NOT fieldName:*)
-     *
-     * @var bool
-     */
-    private $useNotNotation;
+    /** Use the NOT notation: (*:* NOT <expr>), e.g. (*:* NOT fieldName:*) */
+    private bool $useNotNotation;
 
     /**
      * Create new expression object

--- a/src/InterNations/Component/Solr/Expression/BoostExpression.php
+++ b/src/InterNations/Component/Solr/Expression/BoostExpression.php
@@ -11,12 +11,7 @@ use InterNations\Component\Solr\Util;
  */
 class BoostExpression extends Expression
 {
-    /**
-     * Boost factor
-     *
-     * @var float
-     */
-    private $boost;
+    private float $boost;
 
     /**
      * @param ExpressionInterface|string|null $expr

--- a/src/InterNations/Component/Solr/Expression/FieldExpression.php
+++ b/src/InterNations/Component/Solr/Expression/FieldExpression.php
@@ -11,11 +11,7 @@ use InterNations\Component\Solr\Util;
  */
 class FieldExpression extends Expression
 {
-    /**
-     * Field name
-     *
-     * @var string
-     */
+    /** @var ExpressionInterface|string */
     private $field;
 
     /**

--- a/src/InterNations/Component/Solr/Expression/FunctionExpression.php
+++ b/src/InterNations/Component/Solr/Expression/FunctionExpression.php
@@ -5,10 +5,10 @@ use InterNations\Component\Solr\ExpressionInterface;
 
 class FunctionExpression extends Expression
 {
-    /** @var string */
+    /** @var ExpressionInterface|string */
     private $function;
 
-    /** @var array */
+    /** @var ExpressionInterface|array|null */
     private $parameters;
 
     /**

--- a/src/InterNations/Component/Solr/Expression/GeofiltExpression.php
+++ b/src/InterNations/Component/Solr/Expression/GeofiltExpression.php
@@ -3,10 +3,11 @@ namespace InterNations\Component\Solr\Expression;
 
 class GeofiltExpression extends Expression
 {
-    private $field;
-    private $geolocation;
-    private $distance;
-    private $additionalParams;
+    private string $field;
+    private ?GeolocationExpression $geolocation;
+    private int $distance;
+	/** @var mixed[]  */
+    private array$additionalParams;
 
     /**
      * @param mixed[] $additionalParams

--- a/src/InterNations/Component/Solr/Expression/GeofiltExpression.php
+++ b/src/InterNations/Component/Solr/Expression/GeofiltExpression.php
@@ -6,8 +6,9 @@ class GeofiltExpression extends Expression
     private string $field;
     private ?GeolocationExpression $geolocation;
     private int $distance;
-	/** @var mixed[]  */
-    private array$additionalParams;
+
+    /** @var mixed[] */
+    private array $additionalParams;
 
     /**
      * @param mixed[] $additionalParams

--- a/src/InterNations/Component/Solr/Expression/GeolocationExpression.php
+++ b/src/InterNations/Component/Solr/Expression/GeolocationExpression.php
@@ -3,9 +3,9 @@ namespace InterNations\Component\Solr\Expression;
 
 class GeolocationExpression extends Expression
 {
-    private $latitude;
-    private $longitude;
-    private $precision;
+    private float $latitude;
+    private float $longitude;
+    private int $precision;
 
     /** @no-named-arguments */
     public function __construct(float $latitude, float $longitude, int $precision)

--- a/src/InterNations/Component/Solr/Expression/LocalParamsExpression.php
+++ b/src/InterNations/Component/Solr/Expression/LocalParamsExpression.php
@@ -9,11 +9,11 @@ class LocalParamsExpression extends Expression
     /** @var ExpressionInterface|string */
     private $type;
 
-    /** @var array */
-    private $params;
+    /** @var mixed[] */
+    private array $params;
 
     /** @var bool */
-    private $shortForm;
+    private bool $shortForm;
 
     /**
      * @param ExpressionInterface|string $type

--- a/src/InterNations/Component/Solr/Expression/ParameterExpression.php
+++ b/src/InterNations/Component/Solr/Expression/ParameterExpression.php
@@ -5,8 +5,8 @@ use InterNations\Component\Solr\Util;
 
 class ParameterExpression extends Expression
 {
-    /** @var array */
-    private $parameters;
+    /** @var mixed[] */
+    private array $parameters;
 
     /**
      * @param mixed[] $parameters

--- a/src/InterNations/Component/Solr/Expression/ProximityExpression.php
+++ b/src/InterNations/Component/Solr/Expression/ProximityExpression.php
@@ -10,15 +10,11 @@ use InterNations\Component\Solr\Util;
  */
 class ProximityExpression extends Expression
 {
-    /** @var array */
-    private $words;
+    /** @var string[] */
+    private array $words;
 
-    /**
-     * Maximum distance between the two words
-     *
-     * @var int
-     */
-    private $proximity;
+    /** Maximum distance between the two words */
+    private int $proximity;
 
     /**
      * Create new proximity query object

--- a/src/InterNations/Component/Solr/Expression/RangeExpression.php
+++ b/src/InterNations/Component/Solr/Expression/RangeExpression.php
@@ -27,8 +27,10 @@ class RangeExpression extends Expression
 
     /**
      * Inclusive or exclusive the range start/end?
+     *
+     * @var bool
      */
-    protected bool $inclusive;
+    protected $inclusive;
 
     /**
      * Create new range query object

--- a/src/InterNations/Component/Solr/Expression/RangeExpression.php
+++ b/src/InterNations/Component/Solr/Expression/RangeExpression.php
@@ -27,10 +27,8 @@ class RangeExpression extends Expression
 
     /**
      * Inclusive or exclusive the range start/end?
-     *
-     * @var bool
      */
-    protected $inclusive;
+    protected bool $inclusive;
 
     /**
      * Create new range query object

--- a/src/InterNations/Component/Solr/Expression/WildcardExpression.php
+++ b/src/InterNations/Component/Solr/Expression/WildcardExpression.php
@@ -12,12 +12,7 @@ use InterNations\Component\Solr\Util;
  */
 class WildcardExpression extends Expression
 {
-    /**
-     * Wildcard character
-     *
-     * @var string
-     */
-    private $wildcard;
+    private string $wildcard;
 
     /**
      * Wildcard query prefix

--- a/src/InterNations/Component/Solr/Query/QueryString.php
+++ b/src/InterNations/Component/Solr/Query/QueryString.php
@@ -8,11 +8,10 @@ use DateTime;
 
 class QueryString
 {
-    /** @var string */
-    private $query;
+    private string $query;
 
-    /** @var array */
-    private $placeholders = [];
+    /** @var string[] */
+    private array $placeholders = [];
 
     /** @no-named-arguments */
     public function __construct(string $query)

--- a/tests/InterNations/Component/Solr/Tests/AnnotationsTest.php
+++ b/tests/InterNations/Component/Solr/Tests/AnnotationsTest.php
@@ -1,15 +1,10 @@
 <?php
-namespace InterNations\Component\Solr\Tests\Expression;
+namespace InterNations\Component\Solr\Tests;
 
-use CallbackFilterIterator;
 use PHPUnit\Framework\TestCase;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use ReflectionClass;
 use ReflectionMethod;
 use SebastianBergmann\FileIterator\Facade;
-use Symfony\Component\Finder\Finder;
-use function array_walk;
 
 class AnnotationsTest extends TestCase
 {

--- a/tests/InterNations/Component/Solr/Tests/Expression/ExpressionBuilderTest.php
+++ b/tests/InterNations/Component/Solr/Tests/Expression/ExpressionBuilderTest.php
@@ -10,31 +10,28 @@ use PHPUnit\Framework\TestCase;
 
 class ExpressionBuilderTest extends TestCase
 {
-    /**
-     * @var ExpressionBuilder
-     */
-    private $eb;
+    private ExpressionBuilder $eb;
 
     public function setUp(): void
     {
         $this->eb = new ExpressionBuilder();
     }
 
-    public function testEqWithPhrase()
+    public function testEqWithPhrase(): void
     {
         $eq = $this->eb->eq($this->eb->phrase('test foo'));
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\PhraseExpression', $eq);
         $this->assertSame('"test foo"', (string) $eq);
     }
 
-    public function testEqWithTerm()
+    public function testEqWithTerm(): void
     {
         $eq = $this->eb->eq('foo:bar');
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\PhraseExpression', $eq);
         $this->assertSame('"foo\:bar"', (string) $eq);
     }
 
-    public function testEqWithField()
+    public function testEqWithField(): void
     {
         $eq = $this->eb->eq('test');
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\PhraseExpression', $eq);
@@ -44,7 +41,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('field:"test"', (string) $eq);
     }
 
-    public function testPhrase()
+    public function testPhrase(): void
     {
         $p = $this->eb->phrase('foo bar');
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\PhraseExpression', $p);
@@ -55,7 +52,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('field:"foo bar"', (string) $p);
     }
 
-    public function testBoost()
+    public function testBoost(): void
     {
         $b = $this->eb->boost($this->eb->phrase('foo bar'), 10);
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\BoostExpression', $b);
@@ -70,14 +67,14 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('field:"foo bar"^10', (string) $b);
     }
 
-    public function testFieldWithBoolean()
+    public function testFieldWithBoolean(): void
     {
         $f = $this->eb->field('f', false);
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\FieldExpression', $f);
         $this->assertSame('f:false', (string) $f);
     }
 
-    public function testWildcard()
+    public function testWildcard(): void
     {
         $w = $this->eb->wild($this->eb->phrase('foo bar'), '?', 'sfx');
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\WildcardExpression', $w);
@@ -96,7 +93,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('*foo*bar?', (string) $w);
     }
 
-    public function testProhibitedExpr()
+    public function testProhibitedExpr(): void
     {
         $n = $this->eb->prhb('foo');
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\BooleanExpression', $n);
@@ -107,7 +104,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('-field:"foo"', (string) $n);
     }
 
-    public function testRequiredExpr()
+    public function testRequiredExpr(): void
     {
         $n = $this->eb->req('foo');
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\BooleanExpression', $n);
@@ -118,63 +115,63 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('+field:"foo"', (string) $n);
     }
 
-    public function testGrouping()
+    public function testGrouping(): void
     {
         $g = $this->eb->grp($this->eb->phrase('foo bar'));
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\GroupExpression', $g);
         $this->assertSame('("foo bar")', (string) $g);
     }
 
-    public function testGroupingMultipleParams()
+    public function testGroupingMultipleParams(): void
     {
         $g = $this->eb->grp($this->eb->phrase('foo'), $this->eb->phrase('bar'), $this->eb->phrase('baz'));
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\GroupExpression', $g);
         $this->assertSame('("foo" "bar" "baz")', (string) $g);
     }
 
-    public function testGroupingSingleParamAsArray()
+    public function testGroupingSingleParamAsArray(): void
     {
         $g = $this->eb->grp([$this->eb->phrase('bar'), $this->eb->phrase('foo'), $this->eb->phrase('baz')]);
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\GroupExpression', $g);
         $this->assertSame('("bar" "foo" "baz")', (string) $g);
     }
 
-    public function testGroupingWithAndX()
+    public function testGroupingWithAndX(): void
     {
         $g = $this->eb->andX($this->eb->phrase('foo'), $this->eb->phrase('bar'), $this->eb->phrase('baz'));
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\GroupExpression', $g);
         $this->assertSame('("foo" AND "bar" AND "baz")', (string) $g);
     }
 
-    public function testGroupingWithAndXAndEmptyExpressions()
+    public function testGroupingWithAndXAndEmptyExpressions(): void
     {
         $g = $this->eb->andX($this->eb->phrase('foo'), $this->eb->andX(null, null, ''), $this->eb->phrase('bar'));
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\GroupExpression', $g);
         $this->assertSame('("foo" AND "bar")', (string) $g);
     }
 
-    public function testGroupingWithOrX()
+    public function testGroupingWithOrX(): void
     {
         $g = $this->eb->orX($this->eb->phrase('foo'), $this->eb->phrase('bar'), $this->eb->phrase('baz'));
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\GroupExpression', $g);
         $this->assertSame('("foo" OR "bar" OR "baz")', (string) $g);
     }
 
-    public function testGroupingWithOrXAndEmptyExpressions()
+    public function testGroupingWithOrXAndEmptyExpressions(): void
     {
         $g = $this->eb->orX($this->eb->phrase('foo'), $this->eb->orX(null, null, ''), $this->eb->phrase('bar'));
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\GroupExpression', $g);
         $this->assertSame('("foo" OR "bar")', (string) $g);
     }
 
-    public function testField()
+    public function testField(): void
     {
         $f = $this->eb->field('field', 'query');
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\FieldExpression', $f);
         $this->assertSame('field:"query"', (string) $f);
     }
 
-    public function testFuzzy()
+    public function testFuzzy(): void
     {
         $f = $this->eb->fzz('test');
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\FuzzyExpression', $f);
@@ -189,7 +186,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('field:"test"~0.2', (string) $f);
     }
 
-    public function testProximityQuery()
+    public function testProximityQuery(): void
     {
         $p = $this->eb->prx('word1', 'word2', 10);
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\ProximityExpression', $p);
@@ -219,7 +216,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertNull($this->eb->prx(10));
     }
 
-    public function testLiteralStr()
+    public function testLiteralStr(): void
     {
         $expr = $this->eb->lit('foo:bar');
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\Expression', $expr);
@@ -227,7 +224,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('0', (string) $this->eb->lit(0));
     }
 
-    public function testBool()
+    public function testBool(): void
     {
         $expr = $this->eb->bool('foo', true);
         $this->assertInstanceOf('InterNations\Component\Solr\Expression\BooleanExpression', $expr);
@@ -257,7 +254,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('-foo', (string) $expr);
     }
 
-    public function testDayBuilder()
+    public function testDayBuilder(): void
     {
         $date = new DateTime('2010-10-11', new DateTimeZone('UTC'));
         $dayRange = $this->eb->day($date);
@@ -269,7 +266,8 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('dateField:[2010-10-11T00:00:00Z TO 2010-10-11T23:59:59Z]', (string) $dayRange);
     }
 
-    public static function getStartOfDayData()
+	/** @return mixed[] */
+    public static function getStartOfDayData(): array
     {
         return [
             ['2010-10-10T00:00:00Z', '2010-10-11 00:00:00', 'Europe/Berlin'],
@@ -282,7 +280,12 @@ class ExpressionBuilderTest extends TestCase
     }
 
     /** @dataProvider getStartOfDayData */
-    public function testBeginningOfDayBuilder($expected, $date, $timezone, $defaultTimezone = null)
+    public function testBeginningOfDayBuilder(
+		?string $expected,
+		?string $date,
+		?string $timezone,
+		?string $defaultTimezone = null
+	): void
     {
         if ($defaultTimezone) {
             $this->eb->setDefaultTimezone($defaultTimezone);
@@ -294,8 +297,8 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame($expected, $result ? (string) $result : null);
     }
 
-
-    public static function getEndOfDayData()
+	/** @return mixed[] */
+    public static function getEndOfDayData(): array
     {
         return [
             ['2010-10-10T23:59:59Z', '2010-10-11 00:00:00', 'Europe/Berlin'],
@@ -308,7 +311,12 @@ class ExpressionBuilderTest extends TestCase
     }
 
     /** @dataProvider getEndOfDayData */
-    public function testEndOfDayBuilder($expected, $date, $timezone, $defaultTimezone = null)
+    public function testEndOfDayBuilder(
+		?string $expected,
+		?string $date,
+		?string $timezone,
+		?string $defaultTimezone = null
+	): void
     {
         if ($defaultTimezone) {
             $this->eb->setDefaultTimezone($defaultTimezone);
@@ -320,7 +328,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame($expected, $result ? (string) $result : null);
     }
 
-    public function testDefaultQueryForAllIfNullGiven()
+    public function testDefaultQueryForAllIfNullGiven(): void
     {
         $this->assertSame('*:*', (string) $this->eb->all(''));
         $this->assertSame('*:*', (string) $this->eb->all(null));
@@ -328,7 +336,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('0', (string) $this->eb->all('0'));
     }
 
-    public function testFallthroughIfNullGiven()
+    public function testFallthroughIfNullGiven(): void
     {
         $this->assertNull($this->eb->field('field', null));
         $this->assertNotNull($this->eb->field('field', 0));
@@ -366,7 +374,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertNull($this->eb->day(''));
     }
 
-    public function testGroupingTypes()
+    public function testGroupingTypes(): void
     {
         $this->assertSame('("foo" "bar")', (string) $this->eb->grp(['foo', 'bar']));
         $this->assertSame('("foo" AND "bar")', (string) $this->eb->grp(['foo', 'bar'], GroupExpression::TYPE_AND));
@@ -379,7 +387,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('("foo" OR "bar")', (string) $this->eb->grp('foo', 'bar', GroupExpression::TYPE_OR));
     }
 
-    public function testCompositingTypes()
+    public function testCompositingTypes(): void
     {
         $this->assertSame('"foo" "bar"', (string) $this->eb->comp(['foo', 'bar']));
         $this->assertSame('"foo" AND "bar"', (string) $this->eb->comp(['foo', 'bar'], CompositeExpression::TYPE_AND));
@@ -392,7 +400,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('"foo" OR "bar"', (string) $this->eb->comp('foo', 'bar', CompositeExpression::TYPE_OR));
     }
 
-    public function testRealisticQueryExamples()
+    public function testRealisticQueryExamples(): void
     {
         $qb = $this->eb;
 
@@ -426,7 +434,8 @@ class ExpressionBuilderTest extends TestCase
         );
     }
 
-    public static function getDateRangeData()
+	/** @return mixed[] */
+    public static function getDateRangeData(): array
     {
         return [
             [
@@ -573,14 +582,14 @@ class ExpressionBuilderTest extends TestCase
 
     /** @dataProvider getDateRangeData */
     public function testDateRange(
-        $expected,
-        $from,
-        $fromTimezone,
-        $to,
-        $toTimezone,
-        $inclusive = null,
-        $solrTimezone = 'null',
-        $defaultTimezone = null
+        ?string $expected,
+        ?string $from,
+        ?string $fromTimezone,
+        ?string $to,
+        ?string $toTimezone,
+        ?bool $inclusive = null,
+        ?string $solrTimezone = 'null',
+        ?string $defaultTimezone = null
     )
     {
         if ($defaultTimezone) {
@@ -606,14 +615,14 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame($expected, $result !== null ? (string) $result : $result);
     }
 
-    public function testRange()
+    public function testRange(): void
     {
         $this->assertSame('["A" TO "Z"]', (string) $this->eb->range('A', 'Z'));
         $this->assertSame('["A" TO "Z"]', (string) $this->eb->range('A', 'Z', true));
         $this->assertSame('{"A" TO "Z"}', (string) $this->eb->range('A', 'Z', false));
     }
 
-    public function testFunc()
+    public function testFunc(): void
     {
         $this->assertSame('func()', (string) $this->eb->func('func'));
         $this->assertSame('func()', (string) $this->eb->func('func', null));
@@ -626,7 +635,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('func("", "")', (string) $this->eb->func('func', $this->eb->params(null, null)));
     }
 
-    public function testLocalParams()
+    public function testLocalParams(): void
     {
         $this->assertSame('{!dismax}', (string) $this->eb->localParams('dismax'));
         $this->assertSame('{!dismax} "My Query"', (string) $this->eb->localParams('dismax', 'My Query'));
@@ -639,7 +648,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('{!func}field', (string) $this->eb->field('field', $this->eb->localParams('func')));
     }
 
-    public function testGeofilt()
+    public function testGeofilt(): void
     {
         $this->assertSame('{!geofilt sfield="geofield"}', (string) $this->eb->geofilt('geofield'));
         $this->assertSame(
@@ -660,7 +669,7 @@ class ExpressionBuilderTest extends TestCase
         );
     }
 
-    public function testLatLong()
+    public function testLatLong(): void
     {
         $this->assertSame('60.166667000000,24.933333000000', (string) $this->eb->latlong(60.166667, 24.933333));
         $this->assertSame('-33.799508000000,151.284072000000', (string) $this->eb->latlong(-33.799508, 151.284072));
@@ -668,7 +677,8 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('37.7707,-119.5120', (string) $this->eb->latlong(37.770715, -119.512024, 4));
     }
 
-    public static function getDateTimeData()
+	/** @return mixed[] */
+    public static function getDateTimeData(): array
     {
         return [
             ['2012-12-13T14:15:16Z', '2012-12-13 15:15:16', 'Europe/Berlin', 'null'],
@@ -686,11 +696,11 @@ class ExpressionBuilderTest extends TestCase
 
     /** @dataProvider getDateTimeData */
     public function testDateExpressions(
-        $expected,
-        $date,
-        $dateTimezone = null,
-        $solrTimezone = null,
-        $defaultTimezone = null
+        ?string $expected,
+        ?string $date,
+        ?string $dateTimezone = null,
+        ?string $solrTimezone = null,
+        ?string $defaultTimezone = null
     )
     {
         if ($defaultTimezone) {
@@ -707,13 +717,13 @@ class ExpressionBuilderTest extends TestCase
         }
     }
 
-    public function testNoCache()
+    public function testNoCache(): void
     {
         $this->assertSame('{!cache=false}*:*', (string) $this->eb->noCache($this->eb->all()));
         $this->assertSame('', (string) $this->eb->noCache(''));
     }
 
-    public function testTag()
+    public function testTag(): void
     {
         $this->assertSame('{!tag="foo"}*:*', (string)$this->eb->tag('foo', $this->eb->all()));
         $this->assertSame('', (string)$this->eb->tag('foo', null));
@@ -722,7 +732,7 @@ class ExpressionBuilderTest extends TestCase
         $this->assertSame('', (string)$this->eb->excludeTag('foo', null));
     }
 
-    public function testSetInvalidDefaultTimezone()
+    public function testSetInvalidDefaultTimezone(): void
     {
         $this->expectException('InterNations\Component\Solr\Expression\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('Invalid argument #1 $timezone given: expected string or DateTimeZone, got bool');

--- a/tests/InterNations/Component/Solr/Tests/Expression/ExpressionTest.php
+++ b/tests/InterNations/Component/Solr/Tests/Expression/ExpressionTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 
 class ExpressionTest extends TestCase
 {
-    public function testPhraseExpression()
+    public function testPhraseExpression(): void
     {
         $this->assertSame('"foo\:bar"', (string) new PhraseExpression('foo:bar'));
         $this->assertSame('"foo"', (string) new PhraseExpression('foo'));
@@ -30,20 +30,20 @@ class ExpressionTest extends TestCase
         $this->assertSame('"foo bar"', (string) new PhraseExpression('foo bar'));
     }
 
-    public function testWildcardExprEscapesSuffixAndPrefixButNotWildcard()
+    public function testWildcardExprEscapesSuffixAndPrefixButNotWildcard(): void
     {
         $this->assertSame('foo\:bar?bar', (string) new WildcardExpression('?', 'foo:bar', 'bar'));
         $this->assertSame('foo*bar\:foo', (string) new WildcardExpression('*', 'foo', 'bar:foo'));
         $this->assertSame('foo\:bar?', (string) new WildcardExpression('?', 'foo:bar'));
     }
 
-    public function testPhrasesAndWildcards()
+    public function testPhrasesAndWildcards(): void
     {
         $this->assertSame('"foo bar*baz"', (string) new WildcardExpression('*', new PhraseExpression('foo bar'), 'baz'));
         $this->assertSame('"foo bar\:baz*baz"', (string) new WildcardExpression('*', new PhraseExpression('foo bar:baz'), 'baz'));
     }
 
-    public function testGroupingPhrasesAndTerms()
+    public function testGroupingPhrasesAndTerms(): void
     {
         $this->assertSame('("foo\:bar" "foo bar")', (string) new GroupExpression(
             ['foo:bar', new PhraseExpression('foo bar')]
@@ -58,7 +58,7 @@ class ExpressionTest extends TestCase
         ));
     }
 
-    public function testBoostingPhrasesTermsAndGroups()
+    public function testBoostingPhrasesTermsAndGroups(): void
     {
         $this->assertSame('"foo"^10', (string) new BoostExpression(10, 'foo'));
         $this->assertSame('"foo"^10.1', (string) new BoostExpression(10.1, 'foo'));
@@ -66,7 +66,7 @@ class ExpressionTest extends TestCase
         $this->assertSame('("foo" "bar")^200', (string) new BoostExpression(200, new GroupExpression(['foo', 'bar'])));
     }
 
-    public function testFieldExpression()
+    public function testFieldExpression(): void
     {
         $this->assertSame('field:"value\:foo"', (string) new FieldExpression('field', 'value:foo'));
         $this->assertSame(
@@ -76,7 +76,7 @@ class ExpressionTest extends TestCase
         $this->assertSame('fie\-ld:"foo"', (string) new FieldExpression('fie-ld', 'foo'));
     }
 
-    public function testBooleanExpression()
+    public function testBooleanExpression(): void
     {
         $this->assertSame(
             '+("foo" "bar")',
@@ -105,13 +105,13 @@ class ExpressionTest extends TestCase
         );
     }
 
-    public function testProximityExpression()
+    public function testProximityExpression(): void
     {
         $this->assertSame('"foo bar"~100', (string) new ProximityExpression(['foo', 'bar'], 100));
         $this->assertSame('"bar foo"~200', (string) new ProximityExpression(['bar', 'foo'], 200));
     }
 
-    public function testRangeExpression()
+    public function testRangeExpression(): void
     {
         $this->assertSame('["foo" TO "bar"]', (string) new RangeExpression('foo', 'bar', true));
         $this->assertSame('["foo" TO "bar"]', (string) new RangeExpression('foo', 'bar'));
@@ -125,14 +125,14 @@ class ExpressionTest extends TestCase
         $this->assertSame('[0 TO 1]', (string) new RangeExpression(0, 1));
     }
 
-    public function testFuzzyExpression()
+    public function testFuzzyExpression(): void
     {
         $this->assertSame('foo~', (string) new FuzzyExpression('foo'));
         $this->assertSame('foo~0.8', (string) new FuzzyExpression('foo', 0.8));
         $this->assertSame('foo~0', (string) new FuzzyExpression('foo', 0));
     }
 
-    public function testDateExpression()
+    public function testDateExpression(): void
     {
         $this->assertSame(
             '2012-12-13T14:15:16Z',
@@ -148,7 +148,7 @@ class ExpressionTest extends TestCase
         );
     }
 
-    public function testGroupExpression()
+    public function testGroupExpression(): void
     {
         $this->assertSame('(1 2 3)', (string) new GroupExpression([1, 2, 3]));
         $this->assertSame('("one" "two" "three")', (string) new GroupExpression(['one', 'two', 'three']));
@@ -159,7 +159,7 @@ class ExpressionTest extends TestCase
         $this->assertSame('(1 OR 2 OR 3)', (string) new GroupExpression([1, 2, 3], GroupExpression::TYPE_OR));
     }
 
-    public function testFunctionExpression()
+    public function testFunctionExpression(): void
     {
         $this->assertSame('sum(1, 2, 3, "text")', (string) new FunctionExpression('sum', [1, 2, 3, "text"]));
         $this->assertSame('func(1)', (string) new FunctionExpression('func', [1]));
@@ -173,7 +173,7 @@ class ExpressionTest extends TestCase
         );
     }
 
-    public function testLocalParams()
+    public function testLocalParams(): void
     {
         $this->assertSame('{!func}', (string) new LocalParamsExpression('func'));
         $this->assertSame('{!func}', (string) new LocalParamsExpression('func', [], true));
@@ -182,12 +182,12 @@ class ExpressionTest extends TestCase
         $this->assertSame('{!dismax qf="myfield"}', (string) new LocalParamsExpression('dismax', ['qf' => 'myfield']));
     }
 
-    public function testLocalParamsAndField()
+    public function testLocalParamsAndField(): void
     {
         $this->assertSame('{!func}field', (string) new FieldExpression('field', new LocalParamsExpression('func')));
     }
 
-    public function testGeolocationExpression()
+    public function testGeolocationExpression(): void
     {
         $this->assertSame('12.345678901234,89.012345670000', (string) new GeolocationExpression(12.345678901234, 89.01234567, 12));
         $this->assertSame('12.345678900000,89.012345678901', (string) new GeolocationExpression(12.34567890, 89.012345678901, 12));

--- a/tests/InterNations/Component/Solr/Tests/Expression/PerformanceTest.php
+++ b/tests/InterNations/Component/Solr/Tests/Expression/PerformanceTest.php
@@ -17,7 +17,7 @@ class PerformanceTest extends TestCase
         }
     }
 
-    public function testGroupingPerformance_Int()
+    public function testGroupingPerformance_Int(): void
     {
         $list = range(0, 10000);
 
@@ -30,7 +30,7 @@ class PerformanceTest extends TestCase
         );
     }
 
-    public function testGroupingPerformance_Double()
+    public function testGroupingPerformance_Double(): void
     {
         $list = range(0, 10000);
         foreach ($list as $k => $v) {
@@ -46,7 +46,7 @@ class PerformanceTest extends TestCase
         );
     }
 
-    public function testGroupingPerformance_String()
+    public function testGroupingPerformance_String(): void
     {
         $list = range(0, 10000);
         foreach ($list as $k => $v) {

--- a/tests/InterNations/Component/Solr/Tests/Query/QueryStringTest.php
+++ b/tests/InterNations/Component/Solr/Tests/Query/QueryStringTest.php
@@ -10,13 +10,13 @@ use PHPUnit\Framework\TestCase;
 
 class QueryStringTest extends TestCase
 {
-    public function testSimpleQuery()
+    public function testSimpleQuery(): void
     {
         $query = new QueryString('field:value');
         $this->assertSame('field:value', (string) $query);
     }
 
-    public function testQueryWithPlaceholder_String()
+    public function testQueryWithPlaceholder_String(): void
     {
         $query = new QueryString('field:<ph>');
         $this->assertSame('field:<ph>', (string) $query);
@@ -25,14 +25,14 @@ class QueryStringTest extends TestCase
         $this->assertSame('field:"text"', (string) $query);
     }
 
-    public function testPlaceholderSettersReturnItself()
+    public function testPlaceholderSettersReturnItself(): void
     {
         $query = new QueryString('test');
         $this->assertSame($query, $query->setPlaceholder('foo', 'bar'));
         $this->assertSame($query, $query->setPlaceholders(['foo' => 'bar']));
     }
 
-    public function testQueryWithPlaceholder_Group()
+    public function testQueryWithPlaceholder_Group(): void
     {
         $query = new QueryString('field:<ph>');
         $query->setPlaceholder('ph', new GroupExpression(range(0, 3)));
@@ -40,7 +40,7 @@ class QueryStringTest extends TestCase
         $this->assertSame('field:(1 2 3)', (string) $query);
     }
 
-    public function testQueryWithPlaceholder_Date()
+    public function testQueryWithPlaceholder_Date(): void
     {
         $from = new DateTime('2012-10-11 09:08:07', new DateTimeZone('UTC'));
         $to = new DateTime('2013-12-11 10:09:08', new DateTimeZone('UTC'));
@@ -51,7 +51,7 @@ class QueryStringTest extends TestCase
         $this->assertSame('field:[2012-10-11T09:08:07Z TO 2013-12-11T10:09:08Z]', (string) $query);
     }
 
-    public function testQueryWithPlaceholder_Array()
+    public function testQueryWithPlaceholder_Array(): void
     {
         $query = new QueryString('field:<ph>');
         $query->setPlaceholder('ph', [1, 2, 3, 4, 5]);
@@ -59,7 +59,7 @@ class QueryStringTest extends TestCase
         $this->assertSame('field:(1 2 3 4 5)', (string) $query);
     }
 
-    public function testQueryWithPlaceholder_Boolean()
+    public function testQueryWithPlaceholder_Boolean(): void
     {
         $query = new QueryString('field:<ph>');
         $query->setPlaceholder('ph', true);
@@ -69,7 +69,7 @@ class QueryStringTest extends TestCase
         $this->assertSame('field:false', (string) $query);
     }
 
-    public function testQueryWithPlaceholder_Expression()
+    public function testQueryWithPlaceholder_Expression(): void
     {
         $query = new QueryString('field:<ph>');
         $query->setPlaceholder('ph', new RangeExpression(0, 100, false));
@@ -77,7 +77,7 @@ class QueryStringTest extends TestCase
         $this->assertSame('field:{0 TO 100}', (string) $query);
     }
 
-    public function testSetPlaceholders()
+    public function testSetPlaceholders(): void
     {
         $query = new QueryString('field:<ph>');
         $query->setPlaceholders(['ph' => 'text']);


### PR DESCRIPTION
PHP versions 7.1 - 7.3 are outdated and already the end of their life so let’s only support >= 7.4.